### PR TITLE
refactor(search-record): refactor search record logic to return an empty array

### DIFF
--- a/src/services/dataio.service.ts
+++ b/src/services/dataio.service.ts
@@ -115,7 +115,7 @@ export const searchRecords = (req: IReq<SearchRecordsBody>, res: IRes): IRes => 
     const data: object[] = db.readFile();
     const index: number = QueryExecutor.execute(query, data);
     if (index === -1) {
-      return res.status(404).json(generateErrorResponse(ErrorCode.NOT_FOUND, 'No record found')).send();
+      return res.json({ records: [] })
     }
     return res.json({ records: [data[index]] })
   } catch (err) {

--- a/src/services/dataio.service.ts
+++ b/src/services/dataio.service.ts
@@ -117,7 +117,7 @@ export const searchRecords = (req: IReq<SearchRecordsBody>, res: IRes): IRes => 
     if (index === -1) {
       return res.json({ records: [] })
     }
-    return res.json({ records: [data[index]] })
+    return res.json({ records: [data[index]] });
   } catch (err) {
     console.log(`Encountered an error searching data: ${err.message}`);
     return res.status(500).json(generateErrorResponse(ErrorCode.INTERNAL_ERROR, err)).send();


### PR DESCRIPTION
- Search records / Upsert was returning a 404 when no record was found which was causing the whole action/set of actions to fail when they should not
- This should be an empty list returned instead
- Concurrent to this PR Julie will be making documentation changes to make sure this is spelled out for developers